### PR TITLE
Added default value for searchParams arg

### DIFF
--- a/task-manager/src/TaskManager.js
+++ b/task-manager/src/TaskManager.js
@@ -78,7 +78,7 @@ export default class TaskManager {
    * @param searchParams
    * @return {Promise.<TResult>}
    */
-  list({ searchParams }) {
+  list({ searchParams = {} }) {
     return this.machine.promise.resolve(this.search(searchParams));
   }
 


### PR DESCRIPTION
Without this fix calling 
```
taskManager.list({ }).then(...)
```
leads to the exception