### PR TITLE
Restrict `negate` prop only for function invocations in guards and automatic.

### DIFF
--- a/packages/core/src/MachineDefinition.js
+++ b/packages/core/src/MachineDefinition.js
@@ -165,17 +165,16 @@ export default class MachineDefinition {
                 params: implicitParams
               }) :
               // guard is an actual function
-              condition(this.prepareParams({ explicitParams: guards[idx].params, implicitParams }))
-            ).then(result => {
-              // TBD these lines don't seem related to the code below
-              // ??? move them somewhere?
-              //
-              // if guard is resolved with false or is rejected, e.g. transition is not available at the moment
               // pass arguments specified in guard call (part of schema)
               // additionally object, request and context are also passed
               // request should be used to pass params for some dynamic calculations f.e.
               // role dependent transitions and e.t.c
-              return guards[idx].negate ? !result : !!result
+              condition(this.prepareParams({ explicitParams: guards[idx].params, implicitParams }))
+            ).then(result => {
+              // if guard is resolved with false or is rejected, e.g. transition is not available at the moment
+
+              // `negate` property is applied only to function invocations
+              return guards[idx].negate && !guards[idx].expression ? !result : !!result
             })
           })
         ).then(executionResults => resolve(executionResults.every(Boolean))).catch(e => reject(e))
@@ -240,12 +239,14 @@ export default class MachineDefinition {
                 params: implicitParams
               }) :
               // autoGuard is an actual function
+              // pass arguments specified in guard call (part of schema)
+              // additionally object and context are also passed
               autoCondition(this.prepareParams({ explicitParams: automatic[idx].params, implicitParams }))
             ).then(result => {
               // if check return false, return false, e.g. transition is not available at the moment
-              // pass arguments specified in guard call (part of schema)
-              // additionally object and context are also passed
-              return automatic[idx].negate ? !result : !!result
+
+              // `negate` property is applied only to function invocations
+              return automatic[idx].negate && !automatic[idx].expression ? !result : !!result
             })
           })
         ).then(executionResults => resolve(executionResults.every(Boolean))).catch(e => reject(e));

--- a/packages/core/src/specs/MachineDefinition.findAvailableTransitions.spec.js
+++ b/packages/core/src/specs/MachineDefinition.findAvailableTransitions.spec.js
@@ -192,6 +192,17 @@ describe('machine definition: findAvailableTransitions', function() {
                   expression: "not a valid expression"
                 }
               ]
+            },
+            {
+              from: 'i',
+              to: 'j',
+              event: 'i->j',
+              guards: [
+                {
+                  expression: "invoice.enabled === true",
+                  negate: true
+                }
+              ]
             }
           ]
         },
@@ -312,6 +323,19 @@ describe('machine definition: findAvailableTransitions', function() {
       }).catch(err => {
         assert.ok(true)
         done()
+      })
+    });
+
+    it(`expression guard doesn't get negated`, (done) => {
+      machineDefinition.findAvailableTransitions({
+        from: 'i',
+        object: {
+          enabled: true
+        }
+      }).then(({ transitions }) => {
+        assert.equal(transitions.length, 1);
+        assert.equal(transitions[0].event, 'i->j')
+        done();
       })
     });
   });
@@ -583,7 +607,6 @@ describe('machine definition: findAvailableTransitions', function() {
               event: 'i2j',
               automatic: [
                 {
-                  name: 'i2j-auto-expression-guard',
                   expression: 'object.enabled === true'
                 }
               ]
@@ -594,8 +617,18 @@ describe('machine definition: findAvailableTransitions', function() {
               event: 'j2k',
               automatic: [
                 {
-                  name: 'j2k-auto-expression-guard',
                   expression: 'object.enabled === true'
+                }
+              ]
+            },
+            {
+              from: 'k',
+              to: 'l',
+              event: 'k2l',
+              automatic: [
+                {
+                  expression: 'object.enabled === true',
+                  negate: true
                 }
               ]
             }
@@ -736,6 +769,18 @@ describe('machine definition: findAvailableTransitions', function() {
         isAutomatic: true
       }).then(result => {
         assert.equal(result.transitions.length, 0);
+      });
+    });
+
+    it("expression auto-guard doesn't get negated", () => {
+      return machineDefinition.findAvailableTransitions({
+        from: 'k',
+        object: {
+          enabled: true
+        },
+        isAutomatic: true
+      }).then(result => {
+        assert.equal(result.transitions.length, 1);
       });
     });
   });


### PR DESCRIPTION
Changes `core` accroding to issue #63 